### PR TITLE
WIP: Compilation on new linux system with pgplot replacement giza

### DIFF
--- a/contour.f
+++ b/contour.f
@@ -326,7 +326,7 @@ c     the name of otput file is plot.ps,
 c     the device has /VPS tipe
 
 c      write(*,*) 'PLOTINIT before PGOPEN'
-      ier=PGOPEN('plot.ps/VCPS')   
+      ier=PGOPEN('plot.ps/PS')   
 c      ier=PGOPEN('plot.ps/VPS')   
 c      ier=PGOPEN('plot.ps/PS') 
 c      ier=PGOPEN('?')

--- a/makefile_gfortran_rhel
+++ b/makefile_gfortran_rhel
@@ -1,0 +1,100 @@
+# makefile for GENRAY using gnu 64-bit fortran 95 compiler.
+# N.Ershov 
+# 24 Jan, 2003
+# USAGE: 
+# make 		- as usual make
+# make rebuild	- rebuild whole program
+# make clean	- remove all *.o files
+
+SHELL=		/bin/sh
+NAME=		xgenray
+COMPILER=	gfortran
+BUILDER=	$(COMPILER)
+INCLUDES=	antenna.i adj.i bripplb.i cefield.i cone.i dskin.i eps.i\
+		emissa.i five.i fourb.i gr.i grill.i ions.i\
+		limit.i  loopb.i nperpcom.i\
+		lsc_approach.i  lsc_approach_nml.i  lsc_approach_no_nml.i \
+		name_lsc_approach_nml.i \
+		name.i name_eccone.i name_genr.i name_grill.i \
+		name_non_uniform_mesh_profiles_line.i \
+		name_tokamak.i name_uniform_mesh_profiles.i \
+		output.i one.i \
+		onetwo.i oxb.i\
+		rho.i six.i spline_distrib.i three.i \
+		transport_prof.i \
+		write.i writencdf.i \
+		commons.i param.i  rrange.i n_parb.i rkutta.i\
+		globcd.h globcd1.h globcd2.h
+#		netcdf.inc
+SOURCES=	genray.f  abc.f   absorpfw.f absorplh.f   arrays.f\
+		abhay_disp.f\
+		adj_sub.f adj_vmlibpr.f adj_orbit.f adj_control.f \
+		b.f  bcast.f besk.f besk2as.f bessel.f   bound.f\
+		bess_slatec.f besvec.f cn.f\
+		chamber_wall.f \
+		cninit.f   cnpermuz.f  coldm.f   complx.f  cone_ec.f\
+		contour.f croot.f  curba.f curba_GA.f\
+		combine_disp.f \
+                dcom16.f dddrz1.f dense.f dinit.f\
+		dmnf.f dskin.f dten16.f dxdphi.f   dxdr.f   dxdz.f\
+		dydphi.f   dydr.f   dydz.f   efield.f  efield1.f\
+		equilib.f emission.f emission_spectrum.f  eric_disp.f \
+		flown.f  forest.f fokker.f  gamma.f\
+		gr2new.f    gr3.f grill_lh.f   hamilmuz.f   hamilt1.f\
+		hamilt_lambda.f lh_bonoli_disp.f lh_scattering.f limiter.f \
+		lin_liu_curnt.f lh_ql_flux.f lsc_approach.f \
+		mathcurb.f   mk_graph.f mmdei.f  mullerfun2.f  ninit_ec.f \
+		netcdfr3d.f number1.f\
+		outinit.f   output.f  outputb1.f  ono_disp.f oxb.f\
+		partner.f plasmray.f \
+		prep3d.f  prepripl.f  rhospl.f   rk_new.f \
+		read_write_genray_input.f \
+		rkb1.f rside1.f  relat_tens.f scatperp.f shkarofs.f\
+		rsideb1.f   s.f   sdr1.f   se.f   spline.f spldens.f\
+		slatec_ram.f\
+		stop.f tensrcld.f\
+		uertst.f   ugetio.f   uspkd.f\
+		write3d.f x.f   y.f wconvini.f zcunix.f\
+		zfunc.f   zr_psith.f zfun_cur.f
+OBJECTS=	$(SOURCES:.f=.o)
+F90SRCS=	kind_spec.f90 const_and_precisions.f90 quanc8.f90 config_ext.f90 green_func_ext.f90 
+F90OBJS=	$(F90SRCS:.f90=.o)
+LOCATION=	-L$(NETCDF_DIR)/lib -L$(PGPLOT_DIR)/lib 
+#LOCATION  =  -L/usr/local/netcdf-3.5.0/lib -L/usr/X11R6/lib -L/usr/local/pgplot  -L/usr/X11R6/lib -L/usr/lib/gcc-lib/i386-redhat-linux/2.96
+#LIBRARIES=	-lX11 -lnetcdf -lpgplot
+
+LIBRARIES=	-lX11 -lnetcdff -lnetcdf -lpgplot -Wl,-rpath,$(PGPLOT_DIR)/lib
+#LIBRARIES=	-lX11 -lnetcdf -lpgplot -lnetcdf  -lm -llapack -lblas -lg2c
+INCLUDE=/usr/include
+DEBUG=		
+#BH100214:  -ieee not working with gfortran? CSPECIAL= -ieee -frecord-marker=4	
+CSPECIAL= -O3 -frecord-marker=4  -fno-align-commons	
+BSPECIAL=	
+
+#COMPILE=	$(COMPILER) -c $(CSPECIAL) $(DEBUG) -I $(INCLUDE)
+COMPILE=	$(COMPILER) -c $(CSPECIAL) -I $(INCLUDE)
+#BUILD=		$(BUILDER) -o $(NAME) $(BSPECIAL) $(DEBUG)
+BUILD=		$(BUILDER) -o $(NAME) $(BSPECIAL)
+PROTECT=	chmod 755
+DELETE=		rm -f
+
+$(NAME):	$(F90OBJS) $(OBJECTS)
+	$(BUILD) $(F90OBJS) $(OBJECTS) $(LOCATION) $(LIBRARIES)
+	$(PROTECT) $(NAME)
+
+$(F90OBJS): %.o: %.f90
+	$(COMPILE) $< -o $@
+
+$(OBJECTS): %.o: %.f 
+	$(COMPILE) $< -o $@
+
+rebuild:
+	$(COMPILE) $(SOURCES) $(F90SRCS)
+	$(BUILD) $(OBJECTS) $(F90OBJS) $(LOCATION) $(LIBRARIES)
+	$(PROTECT) $(NAME)
+
+clean:
+	$(DELETE) $(OBJECTS) $(F90OBJS) *.mod
+
+#end
+

--- a/makefile_gfortran_rhel8
+++ b/makefile_gfortran_rhel8
@@ -1,0 +1,100 @@
+# makefile for GENRAY using gnu 64-bit fortran 95 compiler.
+# N.Ershov 
+# 24 Jan, 2003
+# USAGE: 
+# make 		- as usual make
+# make rebuild	- rebuild whole program
+# make clean	- remove all *.o files
+
+SHELL=		/bin/sh
+NAME=		xgenray
+COMPILER=	gfortran
+BUILDER=	$(COMPILER)
+INCLUDES=	antenna.i adj.i bripplb.i cefield.i cone.i dskin.i eps.i\
+		emissa.i five.i fourb.i gr.i grill.i ions.i\
+		limit.i  loopb.i nperpcom.i\
+		lsc_approach.i  lsc_approach_nml.i  lsc_approach_no_nml.i \
+		name_lsc_approach_nml.i \
+		name.i name_eccone.i name_genr.i name_grill.i \
+		name_non_uniform_mesh_profiles_line.i \
+		name_tokamak.i name_uniform_mesh_profiles.i \
+		output.i one.i \
+		onetwo.i oxb.i\
+		rho.i six.i spline_distrib.i three.i \
+		transport_prof.i \
+		write.i writencdf.i \
+		commons.i param.i  rrange.i n_parb.i rkutta.i\
+		globcd.h globcd1.h globcd2.h
+#		netcdf.inc
+SOURCES=	genray.f  abc.f   absorpfw.f absorplh.f   arrays.f\
+		abhay_disp.f\
+		adj_sub.f adj_vmlibpr.f adj_orbit.f adj_control.f \
+		b.f  bcast.f besk.f besk2as.f bessel.f   bound.f\
+		bess_slatec.f besvec.f cn.f\
+		chamber_wall.f \
+		cninit.f   cnpermuz.f  coldm.f   complx.f  cone_ec.f\
+		contour.f croot.f  curba.f curba_GA.f\
+		combine_disp.f \
+                dcom16.f dddrz1.f dense.f dinit.f\
+		dmnf.f dskin.f dten16.f dxdphi.f   dxdr.f   dxdz.f\
+		dydphi.f   dydr.f   dydz.f   efield.f  efield1.f\
+		equilib.f emission.f emission_spectrum.f  eric_disp.f \
+		flown.f  forest.f fokker.f  gamma.f\
+		gr2new.f    gr3.f grill_lh.f   hamilmuz.f   hamilt1.f\
+		hamilt_lambda.f lh_bonoli_disp.f lh_scattering.f limiter.f \
+		lin_liu_curnt.f lh_ql_flux.f lsc_approach.f \
+		mathcurb.f   mk_graph.f mmdei.f  mullerfun2.f  ninit_ec.f \
+		netcdfr3d.f number1.f\
+		outinit.f   output.f  outputb1.f  ono_disp.f oxb.f\
+		partner.f plasmray.f \
+		prep3d.f  prepripl.f  rhospl.f   rk_new.f \
+		read_write_genray_input.f \
+		rkb1.f rside1.f  relat_tens.f scatperp.f shkarofs.f\
+		rsideb1.f   s.f   sdr1.f   se.f   spline.f spldens.f\
+		slatec_ram.f\
+		stop.f tensrcld.f\
+		uertst.f   ugetio.f   uspkd.f\
+		write3d.f x.f   y.f wconvini.f zcunix.f\
+		zfunc.f   zr_psith.f zfun_cur.f
+OBJECTS=	$(SOURCES:.f=.o)
+F90SRCS=	kind_spec.f90 const_and_precisions.f90 quanc8.f90 config_ext.f90 green_func_ext.f90 
+F90OBJS=	$(F90SRCS:.f90=.o)
+LOCATION=	-L$(NETCDF_DIR)/lib -L$(PGPLOT_DIR)/lib 
+#LOCATION  =  -L/usr/local/netcdf-3.5.0/lib -L/usr/X11R6/lib -L/usr/local/pgplot  -L/usr/X11R6/lib -L/usr/lib/gcc-lib/i386-redhat-linux/2.96
+#LIBRARIES=	-lX11 -lnetcdf -lpgplot
+
+LIBRARIES=	-lX11 -lnetcdff -lnetcdf -lpgplot -Wl,-rpath,$(PGPLOT_DIR)/lib -Wl,-rpath,$(NETCDF_DIR)/lib
+#LIBRARIES=	-lX11 -lnetcdf -lpgplot -lnetcdf  -lm -llapack -lblas -lg2c
+INCLUDE=/usr/include
+DEBUG=		
+#BH100214:  -ieee not working with gfortran? CSPECIAL= -ieee -frecord-marker=4	
+CSPECIAL= -O3 -frecord-marker=4  -fno-align-commons	
+BSPECIAL=	
+
+#COMPILE=	$(COMPILER) -c $(CSPECIAL) $(DEBUG) -I $(INCLUDE)
+COMPILE=	$(COMPILER) -c $(CSPECIAL) -I $(INCLUDE)
+#BUILD=		$(BUILDER) -o $(NAME) $(BSPECIAL) $(DEBUG)
+BUILD=		$(BUILDER) -o $(NAME) $(BSPECIAL)
+PROTECT=	chmod 755
+DELETE=		rm -f
+
+$(NAME):	$(F90OBJS) $(OBJECTS)
+	$(BUILD) $(F90OBJS) $(OBJECTS) $(LOCATION) $(LIBRARIES)
+	$(PROTECT) $(NAME)
+
+$(F90OBJS): %.o: %.f90
+	$(COMPILE) $< -o $@
+
+$(OBJECTS): %.o: %.f 
+	$(COMPILE) $< -o $@
+
+rebuild:
+	$(COMPILE) $(SOURCES) $(F90SRCS)
+	$(BUILD) $(OBJECTS) $(F90OBJS) $(LOCATION) $(LIBRARIES)
+	$(PROTECT) $(NAME)
+
+clean:
+	$(DELETE) $(OBJECTS) $(F90OBJS) *.mod
+
+#end
+


### PR DESCRIPTION
- GIZA is a modern replacement for the old pgplot library
- Also added a makefile for modern RedHat systems
- I tried the regression test `test-EC-ITER-Centra-CD` and used [nccmp](https://gitlab.com/remikz/nccmp) to compare the gold and new `genray.nc`. There were loads of differences, some were of the order of a few percent. My changes did not cause this. Is the gold `genray.nc` still up to date for the ITER case?
With kind regards
Severin